### PR TITLE
* add link to main releases link for Thrust binary distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ scala-thrust
 
 How to use
 ==========
-Point to thrustshell binary in application.conf.
+The Thrust runtime is platform specific. Latest release may be found [here](https://github.com/breach/thrust/releases)
+
+Point to the thrustshell binary in application.conf.
+
 
 Then use activator run inside example to run.
 


### PR DESCRIPTION
I hadn't heard of thrust, so it took me a while to track down the thrustshell binary you were referring to. I presume this is the correct location?

It would be nice for this to be pulled down automatically as part of the build, yes?
